### PR TITLE
submit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -547,6 +547,17 @@ Selector.prototype.typeIn = function(text, options) {
   });
 };
 
+Selector.prototype.submit = function(options) {
+  var self = this;
+
+  return this.element(options).then(function(element) {
+    debug('submit', element);
+    self.handleEvent({type: 'submit', element: element});
+    blurActiveElement();
+    return $(element).submit();
+  });
+};
+
 Selector.prototype.typeInHtml = function(html, options) {
   var self = this;
 

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,26 @@ scope.click().then(function () {
 });
 ```
 
+## typeIn
+
+Returns a promise that resolves once the element has been found and the text has been entered.
+
+```js
+scope.typeIn(text).then(function () {
+});
+```
+
+* `text` the text to type into the input.
+
+## submit
+
+Returns a promise that resolves once the element has been found and the submit event has been triggered
+
+```js
+scope.submit().then(function () {
+});
+```
+
 ## select
 
 Returns a promise that resolves once the element has been found and the matching item selected from the select box

--- a/sendkeys.js
+++ b/sendkeys.js
@@ -41,4 +41,10 @@ sendkeys.html = function(el, html) {
   dispatchEvent(el, "input");
 };
 
+sendkeys.submit = function(el, html) {
+  console.log('submitting');
+  el.dispatchEvent(new Event('submit'));
+  // dispatchEvent(el, "submit");
+};
+
 module.exports = sendkeys;

--- a/test/browserMonkeySpec.js
+++ b/test/browserMonkeySpec.js
@@ -324,6 +324,22 @@ describe('browser-monkey', function () {
     });
   });
 
+  describe('submit', function () {
+    it('should submit the form', function () {
+      var submitted;
+      var promise = browser.find('input').submit();
+
+      $('<form><input type=text></form>').appendTo(div).submit(function (ev) {
+        submitted = true;
+        ev.preventDefault();
+      });
+
+      return promise.then(function () {
+        expect(submitted).to.be.true;
+      });
+    });
+  });
+
   describe('typeIn', function(){
     it('should eventually enter text into an element', function () {
       var promise = browser.find('.element').typeIn('haha');


### PR DESCRIPTION
Realised we didn't have a `.submit()` on elements.

I was writing something that was listening for an onsubmit event. There was no way to trigger it. One way to do this is with `.typeIn('<enter>')` but not sure?

Anyway I put this in, it's clean but doesn't really relate to the user pressing the enter key.