### PR TITLE
Fix handling of errors from Fill

### DIFF
--- a/index.js
+++ b/index.js
@@ -648,7 +648,7 @@ Selector.prototype.fill = function(field){
       function fillField(){
         var field = fields.shift();
         if (field) {
-          return component.fill(field).then(fillField);
+          return component.fill(field).then(fillField).catch(failure);
         } else {
           success();
         }

--- a/test/browserMonkeySpec.js
+++ b/test/browserMonkeySpec.js
@@ -1098,6 +1098,7 @@ describe('browser-monkey', function () {
       var component = browser.component({
         myAction: function(){
           myActionRan = true;
+
           return new Promise(function(success){
             success();
           });
@@ -1120,26 +1121,21 @@ describe('browser-monkey', function () {
       var component = browser.component({});
       var error;
 
-      return component.fill([
+      var promise = component.fill([
         { actionDoesNotExist: 'name'}
-      ]).then(null, function(e){
-        error = e;
-      }).then(function(){
-        expect(error.message).to.contain('actionDoesNotExist')
-      });
+      ]);
+
+      return expect(promise).to.be.rejectedWith('actionDoesNotExist');
     });
 
     it('throws an error when trying to call an action on a field which does not exist', function(){
       var component = browser.component({});
-      var error;
-
-      return component.fill([
+      
+      var promise = component.fill([
         { typeIn: 'name'}
-      ]).then(null, function(e){
-        error = e;
-      }).then(function(){
-        expect(error.message).to.contain("Field 'name' does not exist");
-      });
+      ]);
+
+      return expect(promise).to.be.rejectedWith("Field 'name' does not exist");
     });
   });
 });


### PR DESCRIPTION
I just couldn't get the tests to fail though, so need to resolve that before merging this. Tried using the expect to be rejected with approach, but same deal, assertions in the tests always seem to pick up the error as expected, but (without this change) when used in my test suite the actual error message does not show up, instead I get:

```
Unhandled rejection Error
    at module.exports (http://localhost:9876/absolute/var/folders/86/1j8grf7x1wb582vbp7_4g4tc0000gn/T/57cb4b53b6935cc75d2d183dca07741f.browserify:49705:15)
    at Component.Selector.resolve 
```


