### PR TITLE
Elements not found for scoped finders return usable CSS selectors

### DIFF
--- a/finders.js
+++ b/finders.js
@@ -108,7 +108,7 @@ module.exports = {
       },
 
       toString: function() {
-        return 'containing: ' + finder.toString();
+        return ':has(' + finder.toString() + ')';
       }
     });
   },
@@ -125,7 +125,7 @@ module.exports = {
   },
 
   printFinders: function (finders) {
-    return finders.map(function (f) { return f.toString(); }).join(' / ');
+    return finders.map(function (f) { return f.toString(); }).join(' ').replace(/\s+\:/g,':');
   },
 
   findElements: function (options) {

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -123,7 +123,7 @@ describe('assertions', function(){
       return Promise.all([
         good1,
         good2,
-        expect(bad).to.be.rejected
+        expect(bad).to.be.rejected()
       ]);
     });
 

--- a/test/findersSpec.js
+++ b/test/findersSpec.js
@@ -117,6 +117,26 @@ describe('find', function () {
       });
     });
 
+    it('errors with a usable css selector if it cant find something', function () {
+      var promise = browser.find('.outer').find('.not-there').element();
+
+      setTimeout(function () {
+        dom.insert('<div class="outer"><div>bad</div></div>');
+      }, 200);
+
+      expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
+    });
+
+    it('errors with a usable css selector if it cant find an element containing another', function () {
+      var promise = browser.find('.outer').containing('.not-there').shouldExist();
+
+      setTimeout(function () {
+        dom.insert('<div class="outer"><div>bad</div></div>');
+      }, 200);
+
+      expect(promise).to.be.rejectedWith('expected to find: .outer:has(.not-there)')
+    });
+
     it("fails if it can't find an element containing another", function () {
       var promise = browser.find('.outer').containing('.inner').shouldExist();
 
@@ -126,6 +146,7 @@ describe('find', function () {
 
       return expect(promise).to.be.rejected;
     });
+
   });
   describe('chains', function () {
     it('eventually finds the inner element, even if the outer element exists', function () {


### PR DESCRIPTION
Fixes #24

e.g.

expected to find: .outer .inner
expected to find: .outer:has(.inner)