### PR TITLE
Default the document option to window.document

### DIFF
--- a/selector.js
+++ b/selector.js
@@ -1,9 +1,10 @@
 var elementTester = require('./elementTester');
+var global = require('global');
 
 function Selector(selector, finders, options) {
   this._selector = selector;
   this._finders = finders || [];
-  this._options = options || { visibleOnly: true, $: require('./jquery'), document: window.document };
+  this._options = options || { visibleOnly: true, $: require('./jquery'), document: global.document };
   this._handlers = [];
   this._elementTesters = elementTester;
 }

--- a/selector.js
+++ b/selector.js
@@ -3,7 +3,7 @@ var elementTester = require('./elementTester');
 function Selector(selector, finders, options) {
   this._selector = selector;
   this._finders = finders || [];
-  this._options = options || { visibleOnly: true, $: require('./jquery')};
+  this._options = options || { visibleOnly: true, $: require('./jquery'), document: window.document };
   this._handlers = [];
   this._elementTesters = elementTester;
 }

--- a/test/domTest.js
+++ b/test/domTest.js
@@ -26,9 +26,6 @@ function domTest(testName, testCb, options){
     runHtml('HTML', function(){
       var htmlDom = createHDom();
       var browser = createBrowser(document.body);
-      browser.set({
-        document: window.document
-      });
       jquery.preventFormSubmit = true;
       return testCb(browser, htmlDom, jquery);
     });


### PR DESCRIPTION
To avoid remembering to `browser.set({ document: window.document })`

Looks like options should actually be merged though...