### PR TITLE
If I say {text:''} I expect empty, not containing '' (everything does)

### DIFF
--- a/elementTester.js
+++ b/elementTester.js
@@ -32,6 +32,12 @@ function getNormalisedText(el) {
   return el.innerText().replace(/ +/g,' ').replace(/ *\n */g,"\n");
 }
 
+function getValue(e, property) {
+  var val = e.val();
+  // Fails with missing value attribute in VDOM without 'string' test (returns SoftSetHook{value: ''})
+  return (typeof val === "string" && val) || '';
+}
+
 module.exports = {
   css: function($el, message, css) {
     if (!$el.is(css)) {
@@ -44,7 +50,7 @@ module.exports = {
     }
   },
   text: function($el, message, text) {
-    assertElementProperties(this.get('$'), $el, text, function (e) { return getNormalisedText(e); });
+    assertElementProperties(this.get('$'), $el, text, function (e) { return getNormalisedText(e)}, text === '');
   },
   length: function($el, message, length) {
     if ($el.length !== length) {
@@ -74,10 +80,10 @@ module.exports = {
     assertElementProperties(this.get('$'), $el, exactText, function (e) { return getNormalisedText(e); }, true);
   },
   value: function($el, message, value) {
-    assertElementProperties(this.get('$'), $el, value, function (e) { return e.val() || ''; });
+    assertElementProperties(this.get('$'), $el, value, getValue, value === '');
   },
   exactValue: function($el, message, exactValue) {
-    assertElementProperties(this.get('$'), $el, exactValue, function (e) { return e.val() || ''; }, true);
+    assertElementProperties(this.get('$'), $el, exactValue, getValue, true);
   },
   attributes: function($el, message, attributes) {
     var $ = this.get('$');

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -82,6 +82,18 @@ describe('assertions', function(){
     ]);
   });
 
+  domTest("treats assertion of text: '' as exact text", function (browser, dom) {
+
+    dom.eventuallyInsert('<div><div class="a">something</div><div class="b"></div></div>');
+
+    return browser.find('.a', {text: 'something'}).shouldExist().then(() => {
+      return Promise.all([
+        browser.find('.a', {text: ''}).shouldNotExist(),
+        browser.find('.b', {text: ''}).shouldExist()
+      ])
+    })
+  });
+
   describe('shouldHave', function () {
     domTest('eventually finds an element and asserts that it has text', function (browser, dom) {
       var good = browser.find('.element').shouldHave({text: 'some t'});
@@ -127,6 +139,21 @@ describe('assertions', function(){
       var good = browser.find('.element1 input').shouldHave({exactValue: 'some text'});
 
       dom.eventuallyInsert('<div class="element1"><input type=text value="some text" /></div>');
+
+      return Promise.all([
+        good,
+        expect(bad).to.be.rejected
+      ]);
+    });
+
+    domTest("treats assertion of value: '' as exact value", function (browser, dom) {
+      var bad = browser.find('.element1 input').shouldHave({value: ''});
+      var good = browser.find('.element2 input').shouldHave({value: ''});
+
+      dom.eventuallyInsert(`<div>
+                               <div class="element1"><input type=text value="some text" /></div>
+                               <div class="element2"><input type=text value="" /></div>
+                            </div>`);
 
       return Promise.all([
         good,


### PR DESCRIPTION
Same for `{value: ''}`

These conditions were always returning true, so you'd have had to say `{exactText/Value: ''}` which is fine, but very counter-intuitive that `{text:''}` is always true.