### PR TITLE
Run tests in mocha before karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 addons:
   firefox: "45.0"
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 addons:
-  firefox: "45.0"
+  firefox: "latest"
   apt:
     sources:
       - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "5.11"
+env:
+  - CXX=g++-4.8
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.12
+  - "5.11"
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "reliable dom testing",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/karma start --browsers Firefox --single-run"
+    "test": "./node_modules/.bin/mocha && ./node_modules/.bin/karma start --browsers Firefox --single-run"
   },
   "author": "Tim Macfarlane <timmacfarlane@gmail.com>",
   "license": "MIT",

--- a/test/actionsSpec.js
+++ b/test/actionsSpec.js
@@ -78,15 +78,13 @@ describe('actions', function(){
   describe('select', function(){
     describe('text', function(){
       domTest('respects timeout option', function(browser, dom, $){
-        var promise = browser.find('.element').select({text: 'Second', timeout: 20});
+        var promise = browser.find('.element').select({text: 'Second', timeout: 3 });
 
         dom.eventuallyInsert(
-          $('<select class="element"><option>First</option><option>Second</option></select>').on('change', function (e) {
-            selectedItem = $(this).find('option[selected]').text();
-          })
-        , 30);
+          $('<select class="element"><option>First</option><option>Second</option></select>')
+        , 6);
 
-        return expect(promise).to.be.rejected
+        return expect(promise).to.be.rejected;
       });
 
       domTest('should eventually select an option element using the text', function(browser, dom, $){
@@ -246,13 +244,13 @@ describe('actions', function(){
       });
     });
     return
-    
+
     [
       '<div class="element"></div>',
       '<input type="checkbox" class="element"></input>',
       '<select class="element"></select>'
     ].forEach(function(html) {
-      
+
       domTest('rejects attempt to type into element: ' + html, function (browser, dom, $) {
         var promise = browser.find('.element').typeIn('whatevs');
         dom.eventuallyInsert(html);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--require ./test/global


### PR DESCRIPTION
This changes `npm test` to run mocha before karma.

The vdom specs already pass under mocha (without karma), except for one spec that was flickering. Simplifying the spec fixed it, I don't really understand why.

Were you running these already @dereke? This seemed too easy :)

```
➜  time karma start --single-run
✔ 229 tests completed
karma start --single-run  8.50s user 2.52s system 73% cpu 14.926 total

➜  time mocha
115 passing (5s)
mocha  1.08s user 0.09s system 23% cpu 4.897 total
```
