### PR TITLE
Promise builder interface

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,0 +1,16 @@
+var promiseBuilder = require('promise-builder');
+
+function apiForComponent(component) {
+  component.within = function(selector, callback) {
+    var api = this;
+    return callback(apiForComponent(component.find(selector)))
+      .then(function() { return api; });
+  }
+  return promiseBuilder(component);
+}
+
+module.exports = {
+  builder: function() {
+    return apiForComponent(this);
+  }
+}

--- a/create.js
+++ b/create.js
@@ -2,10 +2,12 @@ var Selector = require('./selector');
 var finders = require('./finders');
 var actions = require('./actions');
 var assertions = require('./assertions');
+var builder = require('./builder');
 
 module.exports = function(rootSelector) {
   return new Selector(rootSelector)
     .component(finders)
     .component(actions)
-    .component(assertions);
+    .component(assertions)
+    .component(builder);
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "detect-browser": "1.5.0",
     "global": "^4.3.0",
     "jquery": "2.2.4",
+    "promise-builder": "1.0.0",
     "trytryagain": "1.2.0"
   },
   "keywords": [

--- a/test/builderSpec.js
+++ b/test/builderSpec.js
@@ -1,0 +1,64 @@
+var domTest = require('./domTest');
+
+describe('builder()', function(){
+
+  domTest('returns a fluent interface bound to the component', function(browser, dom, $) {
+    var promise = browser.builder()
+      .click('omg')
+      .click('omg')
+      .click('omg');
+
+    var clicks = 0;
+
+    dom.insert('<button class="element">omg</button>').on('click', function () {
+      clicks++;
+    });
+
+    return promise.then(function () {
+      expect(clicks).to.equal(3);
+    });
+  });
+
+  domTest('is compatible with nested components', function (browser, dom) {
+    var user = browser.component({
+      name: function () {
+        return this.find('.user-name');
+      },
+
+      address: function () {
+        return this.find('.user-address');
+      }
+    });
+
+    var promise = user.builder().name().shouldExist().shouldExist();
+
+    dom.eventuallyInsert('<div class="user"><div class="user-name">bob</div><div class="user-address">bob\'s address</div></div>');
+
+    return promise;
+  });
+
+  describe('.within(selector, actions)', function() {
+
+    domTest('passes a new builder to the actions callback', function(browser, dom, $) {
+      var promise = browser.builder()
+        .within('#z', function(z) {
+          return z.click('A').click('A');
+        });
+
+      var clicks = 0;
+
+      var div = $('<div id="z"></div>');
+      var button = $('<button>A</button>');
+      button.on('click', function() {
+        clicks++;
+      })
+      div.append(button);
+      dom.insert(div);
+      return promise.then(function () {
+        expect(clicks).to.equal(2);
+      });
+    });
+
+  })
+
+});


### PR DESCRIPTION
Not ready to merge, I'm just experimenting with an [idea I posted](https://github.com/featurist/browser-monkey/issues/43).

This adds a new [promise builder](https://github.com/featurist/promise-builder) interface to every scope, via `scope.builder()`

The builder interface collapses a chain of scope->method->promise->then->scope->method calls into a chain of scope->method->method. For example:

``` JavaScript
scope.click('Happy').then(function() { return scope.click('Days'); }).then(...)
```

...can be written as:

``` JavaScript
scope.builder().click('Happy').click('Days').then(...)
```

Is this better? worth it?
