### PR TITLE
Print all finders in errors

### DIFF
--- a/finders.js
+++ b/finders.js
@@ -142,14 +142,14 @@ module.exports = {
       }
     });
   },
- 
+
   linkOrButton: function(label) {
     return this.find(
       'a, button, input[type=submit], input[type=button], input[type=reset]',
       {label: label},
       "[linkOrButton: " + label + "]"
     );
-  }, 
+  },
 
   button: function(label) {
     return this.find(
@@ -157,11 +157,11 @@ module.exports = {
       {label: label},
       "[button: " + label + "]"
     );
-  }, 
+  },
 
   link: function(label) {
     return this.find('a', {label: label}, "[link: " + label + "]");
-  }, 
+  },
 
   elements: function (options) {
     options = Options.default(options, {allowMultiple: true});
@@ -191,7 +191,7 @@ module.exports = {
         var found = finder.find(el);
 
         if (!found) {
-          throw new Error("expected to find: " + self.printFinders(self._finders.slice(0, finderIndex + 1)));
+          throw new Error("expected to find: " + self.printFinders(self._finders));
         }
 
         return findWithFinder(found, finderIndex + 1);
@@ -208,7 +208,7 @@ module.exports = {
         selector instanceof Element &&
         selector.tagName == 'IFRAME'
       ) {
-        return selector.contentDocument.body; 
+        return selector.contentDocument.body;
       } else if (
         selector &&
         typeof selector.prop === 'function' &&

--- a/test/actionsSpec.js
+++ b/test/actionsSpec.js
@@ -151,9 +151,7 @@ describe('actions', function(){
 
         dom.eventuallyInsert('<select class="element"><option>First</option><option>Second</option></select>');
 
-        return Promise.all([
-          expect(promise).to.be.rejected
-        ]);
+        return expect(promise).to.be.rejected;
       });
 
       domTest('errors when the input is not a select', function(browser, dom){

--- a/test/findersSpec.js
+++ b/test/findersSpec.js
@@ -153,7 +153,7 @@ describe('find', function () {
         dom.insert('<div class="outer"><div>bad</div></div>');
       }, 200);
 
-      return expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
+      return expect(promise).to.be.rejectedWith('expected to find: .outer:has(.inner)');
     });
 
     domTest('errors with a usable css selector if it cant find an element containing another', function (browser, dom) {

--- a/test/findersSpec.js
+++ b/test/findersSpec.js
@@ -133,7 +133,7 @@ describe('find', function () {
         dom.insert('<div class="outer"><div>bad</div></div>');
       }, 200);
 
-      expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
+      return expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
     });
 
     domTest('errors with a usable css selector if it cant find an element containing another', function (browser, dom) {
@@ -143,7 +143,7 @@ describe('find', function () {
         dom.insert('<div class="outer"><div>bad</div></div>');
       }, 200);
 
-      expect(promise).to.be.rejectedWith('expected to find: .outer:has(.not-there)')
+      return expect(promise).to.be.rejectedWith('expected to find: .outer:has(.not-there)')
     });
 
     domTest("fails if it can't find an element containing another", function (browser, dom) {
@@ -153,7 +153,7 @@ describe('find', function () {
         dom.insert('<div class="outer"><div>bad</div></div>');
       }, 200);
 
-      expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
+      return expect(promise).to.be.rejectedWith('expected to find: .outer .not-there')
     });
 
     domTest('errors with a usable css selector if it cant find an element containing another', function (browser, dom) {
@@ -163,7 +163,7 @@ describe('find', function () {
         dom.insert('<div class="outer"><div>bad</div></div>');
       }, 200);
 
-      expect(promise).to.be.rejectedWith('expected to find: .outer:has(.not-there)')
+      return expect(promise).to.be.rejectedWith('expected to find: .outer:has(.not-there)')
     });
 
     domTest("fails if it can't find an element containing another", function (browser, dom) {


### PR DESCRIPTION
Fixes a bug that was hidden by a couple of specs that weren't returning promises.