### PR TITLE
use element.click() instead of synthetic click events

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,6 +1,5 @@
 var debug = require('debug')('browser-monkey');
 var sendkeys = require('./sendkeys');
-var detect = require('detect-browser');
 
 module.exports = {
   focus: function(element, options) {
@@ -30,16 +29,6 @@ module.exports = {
     }
 
     return self.enabled().element(options).then(function(element) {
-      var isCheckbox = element.prop('tagName') == 'INPUT' && (element.prop('type') || '').toLowerCase() == 'checkbox';
-      var originalCheckedValue;
-
-      if (isCheckbox) {
-        originalCheckedValue = element.prop('checked');
-        if (detect.name == 'ie' || detect.name == 'edge') {
-          element.prop('checked', !originalCheckedValue);
-        }
-      }
-
       debug('click', element);
       self.handleEvent({type: 'click', element: element});
       self.focus(element, options);

--- a/jquery.js
+++ b/jquery.js
@@ -2,26 +2,24 @@ var jquery = require('jquery');
 function dispatchEvent(element, eventType){
   var event;
 
-  if (document.createEvent) {
-    if (eventType === 'click' && (element.tagName === 'A' || element.tagName === 'LABEL')) {
-      var event = document.createEvent("MouseEvents");
-      event.initMouseEvent("click", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-    }
-    else {
+  if (eventType === 'click') {
+    element.click();
+  } else {
+    if (document.createEvent) {
       event = document.createEvent("Event");
       event.initEvent(eventType, true, true);
+    } else {
+      event = document.createEventObject();
+      event.eventType = eventType;
     }
-  } else {
-    event = document.createEventObject();
-    event.eventType = eventType;
-  }
 
-  event.eventName = eventType;
+    event.eventName = eventType;
 
-  if (document.createEvent) {
-    element.dispatchEvent(event);
-  } else {
-    element.fireEvent("on" + event.eventType, event);
+    if (document.createEvent) {
+      element.dispatchEvent(event);
+    } else {
+      element.fireEvent("on" + event.eventType, event);
+    }
   }
 }
 
@@ -34,11 +32,7 @@ if (jquery.fn) {
     trigger: function(eventType){
       for (var i=0; i<this.length; i++){
         var element = this[i];
-        if (eventType === 'click' && element.type === 'checkbox') {
-          element.checked = !element.checked;
-          dispatchEvent(element, eventType);
-        }
-        else if (eventType === 'submit' && element.form) {
+        if (eventType === 'submit' && element.form) {
           if (!jquery.preventFormSubmit) {
             element.form.submit();
           }
@@ -47,7 +41,7 @@ if (jquery.fn) {
         else {
           dispatchEvent(element, eventType);
         }
-      };
+      }
 
       return this;
     },

--- a/test/actionsSpec.js
+++ b/test/actionsSpec.js
@@ -248,7 +248,7 @@ describe('actions', function(){
       return promise.then(function () {
         expect(submitted).to.be.true;
       });
-    });
+    }, {vdom: false});
   });
 
   describe('typeIn', function(){

--- a/test/actionsSpec.js
+++ b/test/actionsSpec.js
@@ -235,6 +235,20 @@ describe('actions', function(){
         expect(submitted).to.be.true;
       });
     });
+
+    domTest('should submit the form when submit button is clicked', function (browser, dom) {
+      var submitted = false;
+      var promise = browser.find('input').click();
+
+      dom.insert('<form action="#"><input type="submit">submit</input></form>').on('submit', function (ev) {
+        ev.preventDefault();
+        submitted = true;
+      });
+
+      return promise.then(function () {
+        expect(submitted).to.be.true;
+      });
+    });
   });
 
   describe('typeIn', function(){

--- a/test/domTest.js
+++ b/test/domTest.js
@@ -6,8 +6,6 @@ var vquery = require('vdom-query')
 var jquery = require('../jquery');
 var createBrowser = require('../create');
 
-function noop(){}
-
 function domTest(testName, testCb, options){
   options = options || {};
 
@@ -16,10 +14,10 @@ function domTest(testName, testCb, options){
   var runVDom = it;
 
   if (options.hasOwnProperty('vdom') && !options.vdom) {
-    runVDom = noop;
+    runVDom = xit;
   }
   if (isNode || (options.hasOwnProperty('html') && !options.html)) {
-    runHtml = noop;
+    runHtml = xit;
   }
 
   runTests(testName, function(){


### PR DESCRIPTION
New versions of chrome seem not to be responding to our own synthetic click events for form submission. This is a fix for that.

* Simplifies checkbox checking (we were doing this manually)
* Simplifies label and anchor clicking