### PR TITLE
improve error when asserting against arrays of values

### DIFF
--- a/elementTester.js
+++ b/elementTester.js
@@ -18,10 +18,33 @@ function assertElementProperties($, elements, expected, getProperty, exact) {
 
     expect(actualTexts.length, 'expected ' + JSON.stringify(actualTexts) + ' to respectively contain ' + JSON.stringify(expected)).to.eql(expected.length);
 
+
+    var comparer = exact == true ?
+      function(a, b) { return a == b; } :
+      function(a, b) { return a.indexOf(b) != -1}
+
+    var found = [];
+    var actuals = actualTexts.slice();
     expected.forEach(function (expected, index) {
-      var actualText = actualTexts[index];
-      assertion(actualText, expected);
+      var actualFound;
+      for (var actualIndex=0; actualIndex<actualTexts.length; actualIndex++) {
+        var actual = actualTexts[actualIndex];
+        if (comparer(actual, expected)) {
+          actualFound = actual;
+          found[actualIndex] = expected;
+          break;
+        }
+      }
     });
+
+    try {
+      expect(found).to.eql(expected)
+    } catch(e) {
+      if (found.slice().sort().toString() == expected.slice().sort().toString()) {
+        e.message += '\nThe text was found but in a different order than specified - maybe you need some sorting?';
+      }
+      throw e;
+    }
   } else {
     var elementText = getProperty($(elements));
     assertion(elementText, expected);
@@ -122,7 +145,6 @@ module.exports = {
       button.find("img").toArray().filter(function(img) {
         return typeof $(img).attr('alt') == 'string' && $(img).attr('alt').indexOf(label) > -1;
       }).length > 0
-      
       }
     });
 

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -134,6 +134,22 @@ describe('assertions', function(){
       ]);
     });
 
+    domTest('error has a tip with suggestions for how to fix it', function(browser, dom){
+      dom.insert('<span>abc</span>');
+      dom.insert('<span>bac</span>');
+      dom.insert('<span>cba</span>');
+
+      return browser.find('span').shouldHave({
+        text: [
+          'cba',
+          'abc',
+          'bac',
+        ]
+      }).catch(function(error) {
+        expect(error.message).to.include('\nThe text was found but in a different order than specified - maybe you need some sorting?');
+      });
+    });
+
     domTest('finds an element with exact value', function (browser, dom) {
       var bad = browser.find('.element1 input').shouldHave({exactValue: 'some t'});
       var good = browser.find('.element1 input').shouldHave({exactValue: 'some text'});
@@ -217,6 +233,14 @@ describe('assertions', function(){
         dom.eventuallyInsert('<select class="element"><option></option><option>Mr</option><option>Mrs</option></select>');
 
         return promise;
+      });
+
+      domTest('fails to find exact text', function(browser, dom){
+        var promise = browser.find('option').shouldHave({exactText: ['', 'Mr', 'Mrs']});
+
+        dom.eventuallyInsert('<select><option>Optional</option><option>Mr</option><option>Mrs</option></select>');
+
+        return expect(promise).to.be.rejected;
       });
     });
 


### PR DESCRIPTION
show the actual and expected array of values when an error occurs.
if the arrays had have matched if they had been sorted then display a message saying that (often the cause of these types of assertions failing)