### PR TITLE
browser.shouldFind(selector, findOptions, existOptions)

### DIFF
--- a/assertions.js
+++ b/assertions.js
@@ -18,6 +18,11 @@ module.exports = {
       .catch(errorHandler(new Error()));
   },
 
+  shouldFind: function (selector, findOptions, existOptions) {
+    return this.find(selector, findOptions)
+      .shouldExist(existOptions)
+  },
+
   shouldNotExist: function (options) {
     return this.notResolve(options)
       .catch(errorHandler(new Error()));

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -53,6 +53,16 @@ describe('assertions', function(){
     });
   });
 
+  describe('shouldFind', function(){
+    domTest('stack trace', function(browser, dom){
+      return browser
+        .shouldFind('div')
+        .assertStackTrace(__filename);
+    }, {
+      mochaOnly: true
+    });
+  });
+
   describe('is', function () {
     domTest('should eventually find an element if it has a class', function (browser, dom) {
       var good = browser.find('.element').is('.good').shouldExist();

--- a/test/findersSpec.js
+++ b/test/findersSpec.js
@@ -9,6 +9,14 @@ describe('find', function () {
     return promise;
   });
 
+  domTest('should eventually find an element, when collapsed into shouldFind(selector)', function (browser, dom) {
+    var promise = browser.shouldFind('.element');
+
+    dom.eventuallyInsert('<div class="element"></div>');
+
+    return promise;
+  });
+
   domTest('should eventually find an element using a filter', function (browser, dom) {
     var promise = browser.find('.element').filter(function (element) {
       return element.hasClass('correct');


### PR DESCRIPTION
I prefer this slightly more "tell don't ask" style, i.e.

```js
browser.shouldFind('.selector')
```
...is equivalent to:
```js
browser.find('.selector').shouldExist()
```
Plus it's a bit shorter. WDYT?