### PR TITLE
browser.set({immediate: true}) for synchronous tests

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -106,6 +106,7 @@ module.exports = {
   fill: function(field){
     var isArray = Object.prototype.toString.call(field) === '[object Array]';
     var component = this;
+    var Promise = this.promise()
     return new Promise(function(success, failure){
       if (isArray) {
         var fields = field;

--- a/create.js
+++ b/create.js
@@ -2,9 +2,11 @@ var Selector = require('./selector');
 var finders = require('./finders');
 var actions = require('./actions');
 var assertions = require('./assertions');
+var promise = require('./promise');
 
 module.exports = function(rootSelector) {
   return new Selector(rootSelector)
+    .component(promise)
     .component(finders)
     .component(actions)
     .component(assertions);

--- a/finders.js
+++ b/finders.js
@@ -1,4 +1,3 @@
-var retry = require('trytryagain');
 var Options = require('./options');
 var expectOneElement = require('./expectOneElement');
 
@@ -233,7 +232,7 @@ module.exports = {
     var retryOptions = Options.remove(options, ['timeout', 'interval']);
     retryOptions.timeout = retryOptions.timeout || defaultTimeout;
 
-    var result = retry(retryOptions, function() {
+    var result = this.retry(retryOptions, function() {
       return self.findElements(options);
     });
 
@@ -243,7 +242,7 @@ module.exports = {
   notResolve: function(options) {
     var self = this;
 
-    return retry(options, function() {
+    return this.retry(options, function() {
       var found = false;
       try {
         self.findElements({allowMultiple: true});

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chai": "3.5.0",
     "debug": "2.2.0",
     "detect-browser": "1.5.0",
+    "finished-promise": "0.0.2",
     "global": "^4.3.0",
     "jquery": "2.2.4",
     "trytryagain": "1.2.0"

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,16 @@
+var FinishedPromise = require('finished-promise');
+var trytryagain = require('trytryagain');
+
+function immediately(retryOptions, fn) {
+  return FinishedPromise.resolve().then(fn);
+}
+
+module.exports = {
+  promise: function () {
+    return this.get('immediate') ? FinishedPromise : Promise;
+  },
+
+  retry: function (options, fn) {
+    return this.get('immediate') ? immediately(options, fn) : trytryagain(options, fn);
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -538,3 +538,13 @@ would match either a link or button according to their respective rules
 
 ## click
 Normally the click action is performed on a scope but you can also provide it with a string `browser.click('monkey')` and it will search for a link or button that matches and perform the click on it.
+
+## Immediate mode
+Although browser-monkey is designed to retry finding elements and assertions, if you can guarantee there will be no delays due to asynchronous application code or rendering, you may prefer to write synchronous tests. In this case, set the `immediate` to `true`:
+
+```js
+browser.set({ immediate: true })
+browser.click('Yummy')
+browser.click('Banana')
+browser.shouldHave({ text: 'Delicious' })
+```

--- a/readme.md
+++ b/readme.md
@@ -540,7 +540,7 @@ would match either a link or button according to their respective rules
 Normally the click action is performed on a scope but you can also provide it with a string `browser.click('monkey')` and it will search for a link or button that matches and perform the click on it.
 
 ## Immediate mode
-Although browser-monkey is designed to retry finding elements and assertions, if you can guarantee there will be no delays due to asynchronous application code or rendering, you may prefer to write synchronous tests. In this case, set the `immediate` to `true`:
+Although browser-monkey is designed to retry finding elements and assertions, if you can guarantee there will be no delays due to asynchronous application code or rendering, you may prefer to write synchronous tests. In this case, set the `immediate` option to `true`:
 
 ```js
 browser.set({ immediate: true })

--- a/selector.js
+++ b/selector.js
@@ -4,7 +4,7 @@ var global = require('global');
 function Selector(selector, finders, options) {
   this._selector = selector;
   this._finders = finders || [];
-  this._options = options || { visibleOnly: true, $: require('./jquery'), document: global.document };
+  this._options = options || { visibleOnly: true, $: require('./jquery'), document: global.document, immediate: false };
   this._handlers = [];
   this._elementTesters = elementTester;
 }

--- a/test/immediateSpec.js
+++ b/test/immediateSpec.js
@@ -1,0 +1,48 @@
+var domTest = require('./domTest');
+
+describe('.set({ immediate: true })', function () {
+  domTest('makes clicks happen immediately', function (browser, dom, $) {
+    var clicked = false;
+
+    dom.insert('<div class="element">red</div>').on('click', function () {
+      clicked = true;
+    })
+
+    browser.set({ immediate: true });
+    browser.find('.element').click();
+    expect(clicked).to.equal(true);
+  });
+
+  domTest('fills a component with supplied values immediately', function(browser, dom){
+    browser.set({ immediate: true });
+
+    var component = browser.component({
+      title: function(){
+        return this.find('.title');
+      },
+      name: function(){
+        return this.find('.name');
+      }
+    });
+    dom.insert('<select class="title"><option>Mrs</option><option>Mr</option></select>');
+    dom.insert('<input type="text" class="name"></input>');
+
+    component.fill([
+      { name: 'title', action: 'select', options: {exactText: 'Mr'}},
+      { name: 'name', action: 'typeIn', options: {text: 'Joe'}}
+    ])
+    expect(dom.el.find('.title').val()).to.equal('Mr');
+    expect(dom.el.find('.name').val()).to.equal('Joe');
+  });
+
+  domTest('throws errors immediately', function (browser, dom, $) {
+    browser.set({ immediate: true });
+    try {
+      browser.find('.element').click();
+    } catch (error) {
+      expect(error.message).to.equal("expected to find: .element [disabled=false]")
+      return
+    }
+    throw new Error("Expected an error")
+  });
+});

--- a/test/immediateSpec.js
+++ b/test/immediateSpec.js
@@ -1,17 +1,26 @@
 var domTest = require('./domTest');
 
 describe('.set({ immediate: true })', function () {
-  domTest('makes clicks happen immediately', function (browser, dom, $) {
-    var clicked = false;
+  describe('click', function () {
+    domTest('makes clicks happen immediately', function (browser, dom, $) {
+      var clicked = false;
 
-    dom.insert('<div class="element">red</div>').on('click', function () {
-      clicked = true;
-    })
+      dom.insert('<div class="element">red</div>').on('click', function () {
+        clicked = true;
+      })
 
-    browser.set({ immediate: true });
-    browser.find('.element').click();
-    expect(clicked).to.equal(true);
-  });
+      browser.set({ immediate: true });
+      browser.find('.element').click();
+      expect(clicked).to.equal(true);
+    });
+
+    domTest('throws errors immediately', function (browser, dom, $) {
+      browser.set({ immediate: true });
+      expect(function () {
+        browser.find('.element').click();
+      }).to.throw('expected to find: .element [disabled=false]')
+    });
+  })
 
   domTest('fills a component with supplied values immediately', function(browser, dom){
     browser.set({ immediate: true });
@@ -35,14 +44,21 @@ describe('.set({ immediate: true })', function () {
     expect(dom.el.find('.name').val()).to.equal('Joe');
   });
 
-  domTest('throws errors immediately', function (browser, dom, $) {
-    browser.set({ immediate: true });
-    try {
-      browser.find('.element').click();
-    } catch (error) {
-      expect(error.message).to.equal("expected to find: .element [disabled=false]")
-      return
-    }
-    throw new Error("Expected an error")
-  });
+  describe('shouldHave', function () {
+    domTest('tests text values immediately', function (browser, dom, $) {
+      dom.insert('<div class="element">red</div>')
+
+      browser.set({ immediate: true });
+      browser.find('.element').shouldHave({text: 'red'});
+    });
+
+    domTest('throws on failure immediately', function (browser, dom, $) {
+      dom.insert('<div class="element">red</div>')
+
+      browser.set({ immediate: true });
+      expect(function () {
+        browser.find('.element').shouldHave({text: 'blue'});
+      }).to.throw('AssertionError: expected element to contain "blue" but contained "red"')
+    });
+  })
 });


### PR DESCRIPTION
Adds an option to switch off retries and promises, for synchronous tests.