### PR TITLE
shouldHave arrays of attributes

### DIFF
--- a/elementTester.js
+++ b/elementTester.js
@@ -112,11 +112,22 @@ module.exports = {
     var $ = this.get('$');
     var elements = $el.toArray();
 
-    elements.forEach(function(el){
-      Object.keys(attributes).forEach(function(attributeKey){
-        expect($(el).attr(attributeKey)).to.equal(attributes[attributeKey]);
+    if (attributes instanceof Array) {
+      expect(elements.length).to.equal(attributes.length, 'expected the matched elements to be the same length as the expected attributes')
+      elements.forEach(function(el, index){
+        var attributesForElement = attributes[index];
+        Object.keys(attributesForElement).forEach(function(attributeKey){
+          expect($(el).attr(attributeKey)).to.equal(attributesForElement[attributeKey]);
+        });
       });
-    });
+
+    } else {
+      elements.forEach(function(el){
+        Object.keys(attributes).forEach(function(attributeKey){
+          expect($(el).attr(attributeKey)).to.equal(attributes[attributeKey]);
+        });
+      });
+    }
   },
 
   label: function($el, message, label) {

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -255,6 +255,28 @@ describe('assertions', function(){
       ]);
     });
 
+    domTest('verifies array of attributes are present', function(browser, dom){
+      dom.insert('<div><img src="/a"/><img src="/b"/><img src="/c"/></div>');
+      var good = browser.find('img').shouldHave({
+        attributes: [
+          {src: '/a'},
+          {src: '/b'},
+          {src: '/c'},
+        ]
+      });
+      var bad = browser.find('img').shouldHave({
+        attributes: [
+          {src: '/c'},
+          {src: '/a'},
+          {src: '/b'},
+        ]
+      });
+      return Promise.all([
+        good,
+        expect(bad).to.be.rejected
+      ]);
+    });
+
     describe('exactText', function(){
       domTest('eventually finds elements that have the exact array of text', function(browser, dom){
         var promise = browser.find('.element option').shouldHave({exactText: ['', 'Mr', 'Mrs']});


### PR DESCRIPTION
allow shouldHave to assert an array of attribues exist on matched elements

```js
  monkey.find('img').shouldHave({
    attributes: [
      {src: '/a.png', alt: 'some picture of an a'},
      {src: '/b.jpg', alt: 'b as a jpg'},
    ]
  })
```