### PR TITLE
fixed issue when expecting multiple text matches

### DIFF
--- a/elementTester.js
+++ b/elementTester.js
@@ -24,18 +24,15 @@ function assertElementProperties($, elements, expected, getProperty, exact) {
       function(a, b) { return a.indexOf(b) != -1}
 
     var found = [];
-    var actuals = actualTexts.slice();
-    expected.forEach(function (expected, index) {
-      var actualFound;
-      for (var actualIndex=0; actualIndex<actualTexts.length; actualIndex++) {
-        var actual = actualTexts[actualIndex];
-        if (comparer(actual, expected)) {
-          actualFound = actual;
-          found[actualIndex] = expected;
-          break;
-        }
+    expected.forEach(function(value) {
+      var foundValue = actualTexts.find(function(actual) {
+        return comparer(actual, value)
+      })
+      if (foundValue != undefined) {
+        actualTexts.splice(actualTexts.indexOf(foundValue), 1)
+        found.push(value)
       }
-    });
+    })
 
     try {
       expect(found).to.eql(expected)

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -158,6 +158,14 @@ describe('assertions', function(){
       ]);
     });
 
+    domTest('finds duplicate text when asserting array of text', function (browser, dom) {
+      dom.insert('<div class="element1">a</div>');
+      dom.insert('<div class="element1">a</div>');
+
+      return browser.find('.element1').shouldHave({text: ['a', 'a']});
+    });
+
+
     domTest('eventually finds an element and asserts that it has value', function (browser, dom) {
       var good1 = browser.find('.element1 input').shouldHave({value: 'some t'});
       var good2 = browser.find('.element2 input').shouldHave({value: 0});


### PR DESCRIPTION
fixes an issue where you want to match multiple elements with the same text

```html
<div>a</div>
<div>a</div>
```
```js
monkey.find('div').shouldHave({text: ['a', 'a']})`
```