### PR TITLE
Fix error message when match of values in an array not found

### DIFF
--- a/lib/elementTester.js
+++ b/lib/elementTester.js
@@ -16,6 +16,7 @@ function assertElementProperties ($, elements, expected, getProperty, exact) {
     var actualTexts = elements.toArray().map(function (item) {
       return getProperty($(item))
     })
+    var originalActualTexts = actualTexts.slice(0)
 
     expect(actualTexts.length, 'expected ' + JSON.stringify(actualTexts) + ' to respectively contain ' + JSON.stringify(expected)).to.eql(expected.length)
 
@@ -33,6 +34,10 @@ function assertElementProperties ($, elements, expected, getProperty, exact) {
         found.push(value)
       }
     })
+
+    if (found.length !== expected.length) {
+      expect(originalActualTexts).to.eql(expected)
+    }
 
     try {
       expect(found).to.eql(expected)

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -198,6 +198,22 @@ describe('assertions', function () {
       })
     })
 
+    domTest('error contains actual element text when no match found', function (browser, dom) {
+      dom.insert('<span>abc</span>')
+      dom.insert('<span>bac</span>')
+      dom.insert('<span>c</span>')
+
+      return browser.find('span').shouldHave({
+        text: [
+          'cba',
+          'abc',
+          'bac'
+        ]
+      }).catch(function (error) {
+        demand(error.message).to.include("expected [ 'abc', 'bac', 'c' ]")
+      })
+    })
+
     domTest('finds an element with exact value', function (browser, dom) {
       var bad = browser.find('.element1 input').shouldHave({exactValue: 'some t'})
       var good = browser.find('.element1 input').shouldHave({exactValue: 'some text'})


### PR DESCRIPTION
when testing an array of elements that does not match the error should contain all of the elements.