### PR TITLE
fix diffs on errors

### DIFF
--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -1,15 +1,6 @@
-function BrowserMonkeyError (message, stack) {
-  this.name = 'BrowserMonkeyError'
-  this.message = message
-  this.stack = stack
-}
-BrowserMonkeyError.prototype = Object.create(Error.prototype)
-BrowserMonkeyError.prototype.constructor = BrowserMonkeyError
-
 module.exports = function (error) {
   return function (e) {
-    var bmError = new BrowserMonkeyError(e.message, error.stack)
-    // bmError.internalError = e;
-    throw bmError
+    e.stack = error.stack
+    throw e
   }
 }

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var expect = require('chai').expect
 var demand = require('must')
 var domTest = require('./domTest')
 
@@ -479,6 +480,25 @@ describe('assertions', function () {
         good1,
         demand(bad1).reject.with.error(/\[ 'one', 'two', 'three' \]/)
       ])
+    })
+
+    domTest('copies error properly', function (browser, dom, $) {
+      var errorThrown
+
+      var good1 = browser.find('.element').shouldHaveElement(function (element) {
+        try {
+          expect($(element).text()).to.eql('not text')
+        } catch (error) {
+          errorThrown = error
+          throw error
+        }
+      })
+
+      dom.eventuallyInsert('<div class="element">text</div>')
+
+      return good1.catch(function (error) {
+        expect(error).to.equal(errorThrown)
+      })
     })
   })
 

--- a/test/assertionsSpec.js
+++ b/test/assertionsSpec.js
@@ -1,5 +1,4 @@
 var assert = require('assert')
-var expect = require('chai').expect
 var demand = require('must')
 var domTest = require('./domTest')
 
@@ -487,7 +486,7 @@ describe('assertions', function () {
 
       var good1 = browser.find('.element').shouldHaveElement(function (element) {
         try {
-          expect($(element).text()).to.eql('not text')
+          assert.equal($(element).text(), 'not text')
         } catch (error) {
           errorThrown = error
           throw error
@@ -497,7 +496,7 @@ describe('assertions', function () {
       dom.eventuallyInsert('<div class="element">text</div>')
 
       return good1.catch(function (error) {
-        expect(error).to.equal(errorThrown)
+        assert.equal(error, errorThrown)
       })
     })
   })


### PR DESCRIPTION
Most assertion libraries put extra information onto the `Error` object so they can do diffs between the actual and expected. This ensures that we keep that information.