### PR TITLE
Don't use `Array.prototype.find` shim

### DIFF
--- a/lib/elementTester.js
+++ b/lib/elementTester.js
@@ -1,7 +1,14 @@
 var chai = require('chai')
 var expect = chai.expect
 var elementsToString = require('./elementsToString')
-require('array.prototype.find').shim()
+
+function arrayFind (list, predicate) {
+  for (var i = 0, len = list.length; i < len; i++) {
+    if (predicate(list[i])) {
+      return list[i]
+    }
+  }
+}
 
 function assertElementProperties ($, elements, expected, getProperty, exact) {
   function assertion (actual, expected) {
@@ -26,7 +33,7 @@ function assertElementProperties ($, elements, expected, getProperty, exact) {
 
     var found = []
     expected.forEach(function (value) {
-      var foundValue = actualTexts.find(function (actual) {
+      var foundValue = arrayFind(actualTexts, function (actual) {
         return comparer(actual, value)
       })
       if (foundValue !== undefined) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
-    "array.prototype.find": "^2.0.3",
     "browserify-optional": "1.0.0",
     "chai": "3.5.0",
     "debug": "^2.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -168,7 +168,7 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-array.prototype.find@^2.0.1, array.prototype.find@^2.0.3:
+array.prototype.find@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.3.tgz#08c3ec33e32ec4bab362a2958e686ae92f59271d"
   dependencies:


### PR DESCRIPTION
Because somehow it causes tests in electron to hang. But only after I
updated osx to High Sierra.

I don't undestand this at all. But not using
the shim seems to be fixing it.